### PR TITLE
Allow passing of callbacks

### DIFF
--- a/lua/nlua/lsp/nvim.lua
+++ b/lua/nlua/lsp/nvim.lua
@@ -84,7 +84,9 @@ nlua_nvim_lsp.setup = function(nvim_lsp, config)
 
     cmd = sumneko_command(),
 
-    on_attach = config.on_attach
+    on_attach = config.on_attach,
+
+    callbacks = config.callbacks
   })
 end
 


### PR DESCRIPTION
Are there other parameters that can be passed to the `nvim_lsp.sumneko_lua.setup` function? If so then could also just do a `vim.tbl_extend('force', config, { ... })` or similar so that they don't all have to be listed explicitly.