### PR TITLE
Make cmd configurable

### DIFF
--- a/lua/nlua/lsp/nvim.lua
+++ b/lua/nlua/lsp/nvim.lua
@@ -82,7 +82,7 @@ nlua_nvim_lsp.setup = function(nvim_lsp, config)
     -- Runtime configurations
     filetypes = {"lua"},
 
-    cmd = sumneko_command(),
+    cmd = config.cmd or sumneko_command(),
 
     on_attach = config.on_attach,
 


### PR DESCRIPTION
I'm using neovim-0.5 beta from ubuntu ppa.
the function that determines cmd value by default uses jit.os . But jit.os is not available in global namespace in my neovim . So the plugin fails to load . Making cmd a configurable option solves any issue regrding that specific function .

The change is minimal it now checks if cmd was passed with the setup call if it was it uses the cmd value that was passed otherwise uses its default function to determine cmd value.

This small change gives more control to user to determine what command is executed to start the lsp server.
