### PR TITLE
Fix main.lua path

### DIFF
--- a/lua/nlua/lsp/nvim.lua
+++ b/lua/nlua/lsp/nvim.lua
@@ -14,7 +14,7 @@ local sumneko_command = function()
     ),
     "-E",
     string.format(
-      "%s/nvim/nvim_lsp/sumneko_lua/lua-language-server/main.lua",
+      "%s/nvim_lsp/sumneko_lua/lua-language-server/main.lua",
       cache_location
     ),
   }


### PR DESCRIPTION
Hi @tjdevries, Thank you for the nice plugin!

I use this plugin in Windows10. And, I cloned `lua_language_server` to `${vim.fn.stdpath('cache')}/nvim_lsp/sumneko_lua/` by myself.
But, nvim_lsp returns errors as the following. This is probably due to the wrong path in main.lua. I'm not certain that this fix is correct, but in my environment, this works well. If you don't like it, please feel free to close it. Thank you.

```
"${vim.fn.stdpath('cache')}/nvim_lsp/sumneko_lua/lua-language-server/bin/Windows/lua-language-server: cannot open ${vim.fn.stdpath('cache')}/nvim/nvim_lsp/sumneko_lua/lua-language-server/main.lua: No such file or directory\r\n"
```