### PR TITLE
fix scripts/download_sumneko for current version of plenary.nvim

### DIFF
--- a/lua/nlua/lsp/nvim.lua
+++ b/lua/nlua/lsp/nvim.lua
@@ -53,11 +53,6 @@ nlua_nvim_lsp.setup = function(nvim_lsp, config)
     return
   end
 
-  if vim.fn.filereadable(cmd[3]) == 0 then
-    print("Could not find resulting build files", cmd[3])
-    return
-  end
-
   nvim_lsp.sumneko_lua.setup({
     cmd = cmd,
 

--- a/scripts/download_sumneko.lua
+++ b/scripts/download_sumneko.lua
@@ -53,7 +53,7 @@ local function build()
   }
 
   run {
-    "./3rd/luamake/luamake", "rebuild",
+    "sh", "-c", "./3rd/luamake/luamake rebuild",
     cwd = directory,
   }
 end


### PR DESCRIPTION
scripts/download_sumneko.lua:56 fails, and upon closer inspection, plenary checks vim.fn.executable(o.cmd) without changing directory to o.cwd beforehand.

my solution is a 'hack' that makes download_sumneko work until plenary.nvim is fixed

basically, I changed:

./3rd/luamake/luamake rebuild -> sh -c "./3rd/luamake/luamake rebuild"